### PR TITLE
feat: add content subdirectory

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: GitHub Pages
+name: Deploy Production
 
 on:
   push:

--- a/public/subdir/index.html
+++ b/public/subdir/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+        <meta name="description" content="Experimenting with GH Page Previews" />
+        <title>Hello GitHub Pages!</title>
+    </head>
+    <body>
+        <h1>Hello World from Sub-directory!</h1>
+    </body>
+</html>


### PR DESCRIPTION
This PR demonstrates that we can publish an arbitrary subdirectory and have a standalone page.