### PR TITLE
refactor: remove production/deploy on PR

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -18,7 +18,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   deploy:
@@ -32,7 +31,6 @@ jobs:
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
         with: 
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
Preview/deploy handles the necessary checks that the site builds, so let's skip executing Production/deploy on Pull Requests entirely.