### PR TITLE
feat: only deploy on content or GHA change, allow manual prod deploy

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -16,6 +16,9 @@ name: Preview
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'public/**'
 
 jobs:
   deploy:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -18,6 +18,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/**'
+      - 'public/**'
+
+  # Allow triggering manually.
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Limits deployments to changes to the public/ directory, the .github/workflows directory, and for production, allows manual deployments.

Only relevant content changes need to trigger the machinery.