### PR TITLE
feat: add a reusable build step and env variation

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -30,6 +30,12 @@ jobs:
         with:
           submodules: recursive # Fetch the Docsy theme
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+      - name: Build
+        # https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
+        uses: ./.github/workflows/reusable_build.yaml
+        with:
+          color: "#CBC3E3"
+          version: ' &middot; <a href="https://github.com/${{ github.repository }}/pull/${{ github.event.number }}">PR-${{ github.event.number }}</a>'
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with: 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -35,6 +35,12 @@ jobs:
         with:
           submodules: recursive # Fetch the Docsy theme
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+      - name: Build
+        # https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
+        uses: ./.github/workflows/reusable_build.yaml
+        with:
+          color: "#AFE1AF"
+          version: ' &middot; <a href="https://github.com/${{ github.repository }}/tree/${{ github.sha }}">${{ github.sha }}</a>'
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with: 

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      color:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+
+jobs:
+  inject_version:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Inject Color
+        run: sed -i 's/#fff/${{ inputs.color }}/' public/*
+      - name: Inject Version
+        run: sed -i 's/#fff/${{ inputs.version }}/' public/*
+
+      
+

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
         <title>Hello GitHub Pages!</title>
     </head>
     <body>
-        <h1>Hello World!</h1>
+        <h1 style="background-color:#fff">Hello World!</h1>
+        <footer>&copy; 2022 &middot; <a href="https://github.com/grayside/gh-page-preview">GitHub</a>#vvv</footer>
     </body>
 </html>


### PR DESCRIPTION
This PR introduces a callable workflow in `reusable_build.yaml`, this is used to power a build step in both production and preview. Build of a more significant app can require multiple steps, this shows how that can be factored out. In the process, it also introduces per-environment theming and customized links back to the published source.