### PR TITLE
feat: cancel on concurrency conflict

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -14,6 +14,8 @@
 
 name: Clean
 
+# This Workflow depends on 'github.event.number',
+# not compatible with branch or manual triggers.
 on:
   pull_request:
     types:
@@ -23,7 +25,8 @@ jobs:
   preview:
     runs-on: ubuntu-20.04
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: preview-${{ github.event.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,6 +14,8 @@
 
 name: Preview
 
+# This workflow depends on 'github.event.number',
+# not compatible with branch or manual triggers.
 on:
   pull_request:
     paths:
@@ -24,7 +26,8 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: preview-${{ github.event.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Build
@@ -48,5 +51,5 @@ jobs:
               issue_number: context.payload.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "🚀 Preview at https://grayside.github.io/gh-page-previews/previews/PR-${{ github.event.number }}/"
+              body: "🔎 Preview at https://${{ github.repository_owner }}.github.io/gh-page-previews/previews/PR-${{ github.event.number }}/"
             })

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Build
@@ -45,4 +46,4 @@ jobs:
           publish_dir: ./public
           # Do not delete previews on each production deploy.
           keep_files: true
-          commit_message: ${{ github.event.head_commit.message }}
+          commit_message: "deploy: ${{ github.event.head_commit.message }}"


### PR DESCRIPTION
This change carries a couple tweaks to the workflows.

1. When concurrency group conflicts occur, instead of queuing the current job is canceled in favor of the latest change.
2. Cleanup and preview share a concurrency group
3. Minor comment, commit message, and notification text tweaks