### PR TITLE
No forking previews

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -22,7 +22,9 @@ on:
       - closed
 
 jobs:
-  preview:
+  remove-preview:
+    # Skip this job when run from a fork. No repository write access means the job would fail.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-20.04
     concurrency:
       group: preview-${{ github.event.number }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -37,6 +37,9 @@ jobs:
           sed -i "s,#fff,$color,g" $(find ./public -type f)
           sed -i "s,#vvv,$version,g" $(find ./public -type f)
       - name: Deploy
+        # Skip this job when run from a fork. No repository write access means the job would fail.
+        # Earlier steps are not skipped to test the build process.
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: peaceiris/actions-gh-pages@v3
         with: 
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,6 +47,8 @@ jobs:
           destination_dir: ./previews/PR-${{ github.event.number }}
           commit_message: ${{ github.event.head_commit.message }}
       - name: Comment
+        # Skip this job when run from a fork. No repository write access means the job would fail.
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
PRs from forks do not have repository write access on the `pull_request` event. As a result, The preview and cleanup jobs fail to build.

`pull_request_target` could be considered, but reading guidance on that, it seems unsafe to risk auto-publishing URL endpoints to arbitrary changes.

Disabling the preview and cleanup operations seems a safe middle-ground.